### PR TITLE
Modified date time regex for format constraints

### DIFF
--- a/src/main/java/seedu/address/model/appointment/AppointmentTime.java
+++ b/src/main/java/seedu/address/model/appointment/AppointmentTime.java
@@ -23,12 +23,12 @@ public class AppointmentTime {
     public static final String MESSAGE_VALID_DATE_CONSTRAINT = "Appointment time should be a valid date and time: ";
 
     public static final String VALIDATION_REGEX =
-            "^(0[1-9]|[12]\\d|3[01])[-/.](0[1-9]|1[0-2])[-/.](\\d{4}) ([01]\\d|2[0-4]):([0-5]\\d)$";
+            "^(\\d{1,2})([-/.])(\\d{1,2})\\2(\\d{4}) (\\d{2}):(\\d{2})$";
 
     public static final List<DateTimeFormatter> FORMATTERS = List.of(
-            DateTimeFormatter.ofPattern("dd-MM-uuuu HH:mm").withResolverStyle(ResolverStyle.STRICT),
-            DateTimeFormatter.ofPattern("dd/MM/uuuu HH:mm").withResolverStyle(ResolverStyle.STRICT),
-            DateTimeFormatter.ofPattern("dd.MM.uuuu HH:mm").withResolverStyle(ResolverStyle.STRICT)
+            DateTimeFormatter.ofPattern("d-M-uuuu HH:mm").withResolverStyle(ResolverStyle.STRICT),
+            DateTimeFormatter.ofPattern("d/M/uuuu HH:mm").withResolverStyle(ResolverStyle.STRICT),
+            DateTimeFormatter.ofPattern("d.M.uuuu HH:mm").withResolverStyle(ResolverStyle.STRICT)
     );
 
     public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm");

--- a/src/main/java/seedu/address/model/person/DateOfBirth.java
+++ b/src/main/java/seedu/address/model/person/DateOfBirth.java
@@ -34,9 +34,9 @@ public class DateOfBirth {
      * and ensure compatibility with the system's date handling logic.
      */
     public static final List<DateTimeFormatter> FORMATTERS = List.of(
-        DateTimeFormatter.ofPattern("dd-MM-uuuu").withResolverStyle(ResolverStyle.STRICT),
-        DateTimeFormatter.ofPattern("dd/MM/uuuu").withResolverStyle(ResolverStyle.STRICT),
-        DateTimeFormatter.ofPattern("dd.MM.uuuu").withResolverStyle(ResolverStyle.STRICT)
+        DateTimeFormatter.ofPattern("d-M-uuuu").withResolverStyle(ResolverStyle.STRICT),
+        DateTimeFormatter.ofPattern("d/M/uuuu").withResolverStyle(ResolverStyle.STRICT),
+        DateTimeFormatter.ofPattern("d.M.uuuu").withResolverStyle(ResolverStyle.STRICT)
     );
 
     /**
@@ -62,7 +62,7 @@ public class DateOfBirth {
      * Separators: -, /, or .
      * Years: Four digits
      */
-    public static final String VALIDATION_REGEX = "^(0[1-9]|[12]\\d|3[01])[-/.](0[1-9]|1[0-2])[-/.](\\d{4})$";
+    public static final String VALIDATION_REGEX = "^(\\d{1,2})([-/.])(\\d{1,2})\\2(\\d{4})$";
 
     public final LocalDate dateOfBirth;
 

--- a/src/test/java/seedu/address/model/appointment/AppointmentTimeTest.java
+++ b/src/test/java/seedu/address/model/appointment/AppointmentTimeTest.java
@@ -32,13 +32,17 @@ class AppointmentTimeTest {
     }
 
     @Test
-    void isValidDateTimeFormat_validAndInvalidCasesFormat() {
+    void isValidDateTimeFormat_validAndInvalidCases() {
+
         assertTrue(AppointmentTime.isValidDateTimeFormat("01-12-2023 14:30"));
         assertTrue(AppointmentTime.isValidDateTimeFormat("01/12/2023 14:30"));
         assertTrue(AppointmentTime.isValidDateTimeFormat("01.12.2023 14:30"));
-        assertFalse(AppointmentTime.isValidDateTimeFormat("2023-12-01 14:30"));
-        assertFalse(AppointmentTime.isValidDateTimeFormat("01-12-2023 25:00"));
-        assertFalse(AppointmentTime.isValidDateTimeFormat("01-12-2023 14:60"));
+
+        // invalid date. Month, year, hour and minute should have the same behavior
+        assertFalse(AppointmentTime.isValidDateTimeFormat("0100-12-2023"));
+
+        assertFalse(AppointmentTime.isValidDateTimeFormat("random string"));
+        assertFalse(AppointmentTime.isValidDateTimeFormat("01-12/2023 25:00")); // different delimiters
         assertFalse(AppointmentTime.isValidDateTimeFormat(""));
     }
 

--- a/src/test/java/seedu/address/model/person/DateOfBirthTest.java
+++ b/src/test/java/seedu/address/model/person/DateOfBirthTest.java
@@ -28,16 +28,20 @@ public class DateOfBirthTest {
         // null date of birth
         assertThrows(NullPointerException.class, () -> DateOfBirth.isValidDateFormat(null));
 
-        // invalid date of birth
+        // invalid format
         assertFalse(DateOfBirth.isValidDateFormat("")); // empty string
         assertFalse(DateOfBirth.isValidDateFormat(" ")); // spaces only
         assertFalse(DateOfBirth.isValidDateFormat("not-a-date"));
-        assertFalse(DateOfBirth.isValidDateFormat("2020-02-30")); // invalid date format
-        assertFalse(DateOfBirth.isValidDateFormat("31/14/1999")); // wrong month
+        assertFalse(DateOfBirth.isValidDateFormat("2020-02-30")); // general invalid format
 
-        // valid date of birth
-        assertTrue(DateOfBirth.isValidDateFormat("31-12-1999"));
-        assertTrue(DateOfBirth.isValidDateFormat("01-01-2000"));
+        // invalid month, date and year should have the same behavior
+        assertFalse(DateOfBirth.isValidDateFormat("31/1444/1999"));
+        assertFalse(DateOfBirth.isValidDateFormat("31-12/19999")); // different delimiters
+
+        // valid format
+        assertTrue(DateOfBirth.isValidDateFormat("31-99-1999"));
+        assertTrue(DateOfBirth.isValidDateFormat("1/1/2000"));
+        assertTrue(DateOfBirth.isValidDateFormat("30.50.2000"));
     }
 
     @Test
@@ -46,8 +50,6 @@ public class DateOfBirthTest {
         assertThrows(NullPointerException.class, () -> DateOfBirth.isValidDateOfBirth(null));
 
         // invalid date
-        assertFalse(DateOfBirth.isValidDateOfBirth("")); // empty string
-        assertFalse(DateOfBirth.isValidDateOfBirth(" ")); // spaces only
         assertFalse(DateOfBirth.isValidDateOfBirth("not-a-date"));
         assertFalse(DateOfBirth.isValidDateOfBirth("2020-02-30")); // invalid date
         assertFalse(DateOfBirth.isValidDateOfBirth("29/02/2025")); // leap day
@@ -55,7 +57,7 @@ public class DateOfBirthTest {
 
         // valid date
         assertTrue(DateOfBirth.isValidDateOfBirth("31-12-1999"));
-        assertTrue(DateOfBirth.isValidDateOfBirth("01-01-2000"));
+        assertTrue(DateOfBirth.isValidDateOfBirth("01/01/2000"));
     }
 
     @Test

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -177,7 +177,7 @@ public class JsonAdaptedPersonTest {
                         VALID_ALCOHOLIC_RECORD, VALID_GENDER, VALID_SMOKING_RECORD, VALID_ALLERGIES,
                         VALID_PAST_MEDICAL_HISTORY, VALID_MEDICINES);
 
-        String expectedMessage = DateOfBirth.MESSAGE_FORMAT_CONSTRAINTS;
+        String expectedMessage = DateOfBirth.MESSAGE_PAST_DATE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 


### PR DESCRIPTION
Now the regex will allow all `dd/mm/yyyy`, and checks the two delimiters are the same

There is also an improvement to allow users to type single digit days and months for convenience